### PR TITLE
Adds a login/logout settings page that connects to homey-oauth2app

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const Homey = require('homey');
+const { OAuth2Util } = require('homey-oauth2app');
+
+
+module.exports = [
+	{
+		description: 'Get logged in state',
+		method: 'GET',
+		path: '/login/',
+		fn: (args, callback) => {
+			if (Homey.app && typeof Homey.app.getSavedOAuth2Sessions === 'function') {
+				let sessions = null;
+				try {
+					sessions = Homey.app.getSavedOAuth2Sessions();
+				} catch (err) {
+					console.error('getSavedOAuth2Sessions() -> error', err.message);
+					return callback(err);
+				}
+				if (Object.keys(sessions).length > 1) {
+					const err = new Error('Multiple OAuth2 sessions found, not allowed.');
+					callback(err);
+					throw err;
+				}
+				if (Object.keys(sessions).length > 0) return callback(null, true);
+				if (Object.keys(sessions).length === 0) return callback(null, false);
+			}
+			return callback(new Error('Could not get current OAuth2 session'));
+		},
+	},
+	{
+		description: 'Set logged in state',
+		method: 'POST',
+		path: '/login/',
+		fn: (args, callback) => {
+			const loginState = args.body.state;
+
+			if (loginState === true) { // login
+
+				// Try get first saved client
+				let client;
+				try {
+					client = Homey.app.getFirstSavedOAuth2Client();
+				} catch (err) {
+					console.error('Could not get first saved OAuth2 client', err);
+				}
+
+				// Create new client since first saved was not found
+				if (!client || client instanceof Error) {
+					console.log('Creating new OAuth2 client');
+					client = Homey.app.createOAuth2Client({
+						sessionId: OAuth2Util.getRandomId(),
+					});
+				}
+
+				// Start OAuth2 process
+				return new Homey.CloudOAuth2Callback(client.getAuthorizationUrl())
+					.on('url', url => Homey.ManagerApi.realtime('url', url))
+					.on('code', code => {
+						client.getTokenByCode({ code })
+							.then(async () => {
+								// get the client's session info
+								const session = await client.onGetOAuth2SessionInformation();
+								const token = client.getToken();
+								const title = session.title;
+								client.destroy();
+
+								// replace the temporary client by the final one and save it
+								client = Homey.app.createOAuth2Client({
+									sessionId: session.id,
+								});
+								client.setTitle({ title });
+								client.setToken({ token });
+								client.save();
+
+								Homey.ManagerApi.realtime('authorized');
+
+								// Get Toon devices
+								const toonDevices = Homey.ManagerDrivers.getDriver('toon').getDevices();
+								toonDevices.forEach(toonDevice => {
+
+									// Call resetOAuth2Client on device to re-bind a new OAuth2Client instance to the device
+									toonDevice.resetOAuth2Client({
+										sessionId: session.id,
+										configId: Homey.ManagerDrivers.getDriver('toon').getOAuth2ConfigId(),
+									}).catch(console.error);
+								});
+							})
+							.catch(err => {
+								console.error('error', err.message || err.toString());
+								Homey.ManagerApi.realtime('error', err);
+							});
+					})
+					.generate();
+
+			} else if (loginState === false) { // logout
+				if (Homey.app && typeof Homey.app.getSavedOAuth2Sessions === 'function') {
+					let sessions = null;
+
+					// Get OAuth2 sessions
+					try {
+						sessions = Homey.app.getSavedOAuth2Sessions();
+					} catch (err) {
+						console.error('getSavedOAuth2Sessions() -> error', err.message);
+						return callback(err);
+					}
+
+					// Loop all sessions and deleted the related clients
+					for (const [sessionId, session] of Object.entries(sessions)) {
+						console.log(`Delete client based on session (sessionId: ${sessionId}, configId: ${session.configId})`);
+						try {
+							Homey.app.deleteOAuth2Client({ sessionId, configId: session.configId });
+						} catch (err) {
+							console.error('could not delete OAuth2Client', err);
+						}
+					}
+
+					// Get Toon devices
+					const toonDevices = Homey.ManagerDrivers.getDriver('toon').getDevices();
+
+					// Mark all Toon devices is unavailable
+					toonDevices.forEach(toonDevice => toonDevice.setUnavailable(Homey.__('re-authorize')));
+					return callback(null, true);
+				}
+				return callback(new Error('Could not get current OAuth2 session'));
+			}
+			throw new Error(`Invalid login state received ${loginState}`);
+		},
+	},
+];

--- a/api.js
+++ b/api.js
@@ -1,131 +1,58 @@
 'use strict';
 
 const Homey = require('homey');
-const { OAuth2Util } = require('homey-oauth2app');
-
 
 module.exports = [
 	{
 		description: 'Get logged in state',
 		method: 'GET',
 		path: '/login/',
-		fn: (args, callback) => {
-			if (Homey.app && typeof Homey.app.getSavedOAuth2Sessions === 'function') {
-				let sessions = null;
-				try {
-					sessions = Homey.app.getSavedOAuth2Sessions();
-				} catch (err) {
-					console.error('getSavedOAuth2Sessions() -> error', err.message);
-					return callback(err);
-				}
-				if (Object.keys(sessions).length > 1) {
-					const err = new Error('Multiple OAuth2 sessions found, not allowed.');
-					callback(err);
-					throw err;
-				}
-				if (Object.keys(sessions).length > 0) return callback(null, true);
-				if (Object.keys(sessions).length === 0) return callback(null, false);
+		fn: async (args, callback) => {
+			// Check if app.js is done
+			if (!Homey || !Homey.app || typeof Homey.app.isAuthenticated !== 'function') {
+				return callback(new Error(Homey.__('api.retry')));
 			}
-			return callback(new Error('Could not get current OAuth2 session'));
+
+			// Try to get the authenticated state
+			try {
+				const authenticated = await Homey.app.isAuthenticated();
+				return callback(null, authenticated);
+			} catch (err) {
+				return callback(new Error(Homey.__('api.error_get_authenticated_state', { error: err.message || err.toString() })));
+			}
 		},
 	},
 	{
 		description: 'Set logged in state',
 		method: 'POST',
 		path: '/login/',
-		fn: (args, callback) => {
-			const loginState = args.body.state;
-
-			if (loginState === true) { // login
-
-				// Try get first saved client
-				let client;
-				try {
-					client = Homey.app.getFirstSavedOAuth2Client();
-				} catch (err) {
-					console.error('Could not get first saved OAuth2 client', err);
-				}
-
-				// Create new client since first saved was not found
-				if (!client || client instanceof Error) {
-					console.log('Creating new OAuth2 client');
-					client = Homey.app.createOAuth2Client({
-						sessionId: OAuth2Util.getRandomId(),
-					});
-				}
-
-				// Start OAuth2 process
-				return new Homey.CloudOAuth2Callback(client.getAuthorizationUrl())
-					.on('url', url => Homey.ManagerApi.realtime('url', url))
-					.on('code', code => {
-						client.getTokenByCode({ code })
-							.then(async () => {
-								// get the client's session info
-								const session = await client.onGetOAuth2SessionInformation();
-								const token = client.getToken();
-								const title = session.title;
-								client.destroy();
-
-								// replace the temporary client by the final one and save it
-								client = Homey.app.createOAuth2Client({
-									sessionId: session.id,
-								});
-								client.setTitle({ title });
-								client.setToken({ token });
-								client.save();
-
-								Homey.ManagerApi.realtime('authorized');
-
-								// Get Toon devices
-								const toonDevices = Homey.ManagerDrivers.getDriver('toon').getDevices();
-								toonDevices.forEach(toonDevice => {
-
-									// Call resetOAuth2Client on device to re-bind a new OAuth2Client instance to the device
-									toonDevice.resetOAuth2Client({
-										sessionId: session.id,
-										configId: Homey.ManagerDrivers.getDriver('toon').getOAuth2ConfigId(),
-									}).catch(console.error);
-								});
-							})
-							.catch(err => {
-								console.error('error', err.message || err.toString());
-								Homey.ManagerApi.realtime('error', err);
-							});
-					})
-					.generate();
-
-			} else if (loginState === false) { // logout
-				if (Homey.app && typeof Homey.app.getSavedOAuth2Sessions === 'function') {
-					let sessions = null;
-
-					// Get OAuth2 sessions
-					try {
-						sessions = Homey.app.getSavedOAuth2Sessions();
-					} catch (err) {
-						console.error('getSavedOAuth2Sessions() -> error', err.message);
-						return callback(err);
-					}
-
-					// Loop all sessions and deleted the related clients
-					for (const [sessionId, session] of Object.entries(sessions)) {
-						console.log(`Delete client based on session (sessionId: ${sessionId}, configId: ${session.configId})`);
-						try {
-							Homey.app.deleteOAuth2Client({ sessionId, configId: session.configId });
-						} catch (err) {
-							console.error('could not delete OAuth2Client', err);
-						}
-					}
-
-					// Get Toon devices
-					const toonDevices = Homey.ManagerDrivers.getDriver('toon').getDevices();
-
-					// Mark all Toon devices is unavailable
-					toonDevices.forEach(toonDevice => toonDevice.setUnavailable(Homey.__('re-authorize')));
-					return callback(null, true);
-				}
-				return callback(new Error('Could not get current OAuth2 session'));
+		fn: async (args, callback) => {
+			if (!args || !args.body || !args.body.hasOwnProperty('state') ||
+								typeof args.body.state !== 'boolean') {
+				return callback(new Error(Homey.__('api.retry')));
 			}
-			throw new Error(`Invalid login state received ${loginState}`);
+			const loginState = args.body.state;
+			if (loginState === true) { // login
+				if (!Homey || !Homey.app || typeof Homey.app.login !== 'function') {
+					return callback(new Error(Homey.__('api.retry')));
+				}
+				try {
+					await Homey.app.login();
+					return callback(null, true);
+				} catch (err) {
+					return callback(new Error(Homey.__('api.error_login_failed', { error: err.message || err.toString() })));
+				}
+			} else if (loginState === false) { // logout
+				if (!Homey || !Homey.app || typeof Homey.app.logout !== 'function') {
+					return callback(new Error(Homey.__('api.retry')));
+				}
+				try {
+					await Homey.app.logout();
+					return callback(null, true);
+				} catch (err) {
+					return callback(new Error(Homey.__('api.error_logout_failed', { error: err.message || err.toString() })));
+				}
+			}
 		},
 	},
 ];

--- a/app.js
+++ b/app.js
@@ -2,9 +2,11 @@
 
 const Homey = require('homey');
 const Log = require('homey-log').Log;
-const { OAuth2App } = require('homey-oauth2app');
+const { OAuth2App, OAuth2Util } = require('homey-oauth2app');
 
 const ToonOAuth2Client = require('./lib/ToonOAuth2Client');
+
+const TOON_DRIVER_NAME = 'toon';
 
 class ToonApp extends OAuth2App {
 
@@ -20,6 +22,117 @@ class ToonApp extends OAuth2App {
 		});
 
 		this.log(`${this.id} running...`);
+	}
+
+	get ToonDriver() {
+		return Homey.ManagerDrivers.getDriver(TOON_DRIVER_NAME);
+	}
+
+	async isAuthenticated() {
+		try {
+			const session = await this._getSession();
+			this.log(`isAuthenticated() -> ${!!session}`);
+			return !!session;
+		} catch (err) {
+			this.error('isAuthenticated() -> could not get current session:', err);
+			throw new Error('Could not get current OAuth2 session');
+		}
+	}
+
+	async login() {
+		this.log('login()');
+
+		// Try get first saved client
+		let client;
+		try {
+			client = this.getFirstSavedOAuth2Client();
+		} catch (err) {
+			this.log('login() -> no existing OAuth2 client available');
+		}
+
+		// Create new client since first saved was not found
+		if (!client || client instanceof Error) {
+			client = this.createOAuth2Client({ sessionId: OAuth2Util.getRandomId() });
+		}
+
+		this.log('login() -> created new temporary OAuth2 client');
+
+		// Start OAuth2 process
+		return new Homey.CloudOAuth2Callback(client.getAuthorizationUrl())
+			.on('url', url => Homey.ManagerApi.realtime('url', url))
+			.on('code', async code => {
+				this.log('login() -> received OAuth2 code');
+				try {
+					await client.getTokenByCode({ code });
+				} catch (err) {
+					this.error('login() -> could not get token by code', err);
+					Homey.ManagerApi.realtime('error', new Error(Homey.__('authentication.re-login_failed_with_error', { error: err.message || err.toString() })));
+				}
+				// get the client's session info
+				const session = await client.onGetOAuth2SessionInformation();
+				const token = client.getToken();
+				const title = session.title;
+				client.destroy();
+
+				try {
+					// replace the temporary client by the final one and save it
+					client = this.createOAuth2Client({ sessionId: session.id });
+					client.setTitle({ title });
+					client.setToken({ token });
+					client.save();
+				} catch (err) {
+					this.error('Could not create new OAuth2 client', err);
+					Homey.ManagerApi.realtime('error', new Error(Homey.__('authentication.re-login_failed_with_error', { error: err.message || err.toString() })));
+				}
+
+				this.log('login() -> authenticated');
+				Homey.ManagerApi.realtime('authorized');
+
+				// Get Toon devices and call resetOAuth2Client on device to re-bind a new OAuth2Client
+				// instance to the device
+				try {
+					await this.ToonDriver
+						.getDevices()
+						.forEach(toonDevice => toonDevice.resetOAuth2Client({
+							sessionId: session.id,
+							configId: this.ToonDriver.getOAuth2ConfigId(),
+						}));
+				} catch (err) {
+					this.error('Could not reset OAuth2 client on Toon device instance', err);
+					Homey.ManagerApi.realtime('error', new Error(Homey.__('authentication.re-login_failed_with_error', { error: err.message || err.toString() })));
+				}
+				this.log('login() -> reset devices to new OAuth2 client');
+			})
+			.generate();
+	}
+
+	async logout() {
+		this.log('logout()');
+		const session = await this._getSession();
+		const sessionId = Object.keys(session)[0];
+		this.deleteOAuth2Client({ sessionId, configId: session.configId });
+
+		// Get Toon devices and mark as unavailable
+		return Promise.all(
+			this.ToonDriver
+				.getDevices()
+				.map(toonDevice => toonDevice.setUnavailable(Homey.__('authentication.re-authorize')))
+		);
+	}
+
+	async _getSession() {
+		let sessions = null;
+		try {
+			sessions = this.getSavedOAuth2Sessions();
+		} catch (err) {
+			this.error('isAuthenticated() -> error', err.message);
+			throw err;
+		}
+		if (Object.keys(sessions).length > 1) {
+			throw new Error('Multiple OAuth2 sessions found, not allowed.');
+		}
+		this.log('_getSession() ->', Object.keys(sessions).length === 1 ? Object.keys(sessions)[0] : 'no session found');
+		return Object.keys(sessions).length === 1 ? sessions : null;
 	}
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,6 +2,9 @@
   "reconnecting": "Reconnecting...",
   "connecting": "Connecting...",
   "offline": "Toon is unreachable",
+  "re-authorize": "Please re-authorize through the Toon App Settings.",
+  "device_absent_in_account": "Device could not be found, try logging in again with the right Toon account.",
+  "oauth2_client_reset_failed": "Something went wrong when logging in.",
   "initialization_error": "Something went wrong, error: __error__",
   "unauthenticated": "Toon lost the connection, please re-pair this device",
   "repair_migration_v3": "Due to an incompatibility between Toon API versions this device needs to be re-paired.",
@@ -17,5 +20,13 @@
     "retry": "Retry",
     "installed_toon": "This Toon® was already installed!",
     "installed_toon_explained": "It seems that the Toon® connected to this account was already installed on this Homey, please try a different account if you would like to add another Toon device."
+  },
+  "settings": {
+    "title": "Toon Account",
+    "login_intro": "Click here to login with your Toon account.",
+    "login_button": "Login",
+    "logged_in": "You are currently logged in.",
+    "logout_intro": "Click here to logout.",
+    "logout_button": "Logout"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,26 +1,4 @@
 {
-  "reconnecting": "Reconnecting...",
-  "connecting": "Connecting...",
-  "offline": "Toon is unreachable",
-  "re-authorize": "Please re-authorize through the Toon App Settings.",
-  "device_absent_in_account": "Device could not be found, try logging in again with the right Toon account.",
-  "oauth2_client_reset_failed": "Something went wrong when logging in.",
-  "initialization_error": "Something went wrong, error: __error__",
-  "unauthenticated": "Toon lost the connection, please re-pair this device",
-  "repair_migration_v3": "Due to an incompatibility between Toon API versions this device needs to be re-paired.",
-  "pair": {
-    "error": "Something went wrong, please try again... \n__error__",
-    "login": "Please login",
-    "username": "Username",
-    "password": "Password",
-    "found_toon": "Homey found Toon®!",
-    "no_toon": "Homey couldn't find Toon®...",
-    "no_toon_explained": "It appears there is no new Toon® device to be found.",
-    "found_toon_explained": "Toon® has been added as a device to your Homey!",
-    "retry": "Retry",
-    "installed_toon": "This Toon® was already installed!",
-    "installed_toon_explained": "It seems that the Toon® connected to this account was already installed on this Homey, please try a different account if you would like to add another Toon device."
-  },
   "settings": {
     "title": "Toon Account",
     "login_intro": "Click here to login with your Toon account.",
@@ -28,5 +6,25 @@
     "logged_in": "You are currently logged in.",
     "logout_intro": "Click here to logout.",
     "logout_button": "Logout"
+  },
+  "authentication": {
+    "connecting": "Connecting...",
+    "re-authorize": "Please re-authorize through the Toon App Settings.",
+    "device_not_found": "Device could not be found, try logging in again with the right Toon account.",
+    "re-login_failed": "Something went wrong when logging in.",
+    "re-login_failed_with_error": "Something went wrong when logging in (error: __error__)"
+  },
+  "capability": {
+    "error_enable_program": "Could not enable program (error: __error__)",
+    "error_disable_program": "Could not disable program (error: __error__)",
+    "error_set_temperature_state": "Could not change temperature state (error: __error__)",
+    "error_set_target_temperature": "Could not change target temperature (error: __error__)",
+    "error_set_target_temperature_invalid_value": "Could not change target temperature, invalid temperature value (error: __error__)"
+  },
+  "api": {
+    "retry": "Something went wrong, try again later.",
+    "error_login_failed": "Could not login (error: __error___)",
+    "error_logout_failed": "Could not logout (error: __error___)",
+    "error_get_authenticated_state": "Could not get current login state (error: __error___)"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,26 +1,4 @@
 {
-  "reconnecting": "Bezig met verbinden...",
-  "connecting": "Bezig met verbinden...",
-  "offline": "Toon is onbereikbaar",
-  "re-authorize": "Log opnieuw in via de Toon App Instellingen.",
-  "device_absent_in_account": "Apparaat niet gevonden, probeer opnieuw in te loggen met het juiste Toon account.",
-  "oauth2_client_reset_failed": "Er is iets fout gegaan bij het opnieuw inloggen.",
-  "initialization_error": "Er ging iets fout, error: __error__",
-  "unauthenticated": "Toon is de verbinding kwijt, voeg het apparaat opnieuw toe",
-  "repair_migration_v3": "Vanwege de incompatibiliteit tussen Toon API versies moet dit apparaat opnieuw worden toegevoegd.",
-  "pair": {
-    "error": "Er ging iets fout, probeer het opnieuw... \n__error__",
-    "login": "Inloggen",
-    "username": "Gebruikersnaam",
-    "password": "Wachtwoord",
-    "found_toon": "Homey heeft Toon® gevonden!",
-    "no_toon": "Homey kon Toon® niet vinden...",
-    "no_toon_explained": "Het lijkt er op dat er geen nieuw Toon",
-    "found_toon_explained": "Toon® is succesvol gekoppeld aan je Homey!",
-    "retry": "Probeer opnieuw",
-    "installed_toon": "Deze Toon® is al geïnstalleerd!",
-    "installed_toon_explained": "Het lijkt er op dat de Toon® die verbonden is met dit account reeds geïnstalleerd is op deze Homey, wil je nog een Toon apparaat toevoegen, probeer dan een ander account."
-  },
   "settings": {
     "title": "Toon Account",
     "login_intro": "Klik hier om in te loggen met je Toon account.",
@@ -28,5 +6,25 @@
     "logged_in": "Je bent momenteel ingelogd.",
     "logout_intro": "Klik hier om uit te loggen.",
     "logout_button": "Log uit"
+  },
+  "authentication": {
+    "connecting": "Bezig met verbinden...",
+    "re-authorize": "Log opnieuw in via de Toon App Instellingen.",
+    "device_not_found": "Apparaat niet gevonden, probeer opnieuw in te loggen met het juiste Toon account.",
+    "re-login_failed": "Er is iets fout gegaan bij het opnieuw inloggen.",
+    "re-login_failed_with_error": "Er is iets fout gegaan bij het opnieuw inloggen (error: __error__)"
+  },
+  "capability": {
+    "error_enable_program": "Kon programma niet aanzetten (error: __error__)",
+    "error_disable_program": "Kon programma niet uitzetten (error: __error__)",
+    "error_set_temperature_state": "Kon temperatuurstand niet aanpassen (error: __error__)",
+    "error_set_target_temperature": "Kon doeltemperatuur niet instellen (error: __error__)",
+    "error_set_target_temperature_invalid_value": "Kon doeltemperatuur niet instellen, ongeldige temperatuur waarde (error: __error__)"
+  },
+  "api": {
+    "retry": "Er ging iets fout, probeer het later opnieuw.",
+    "error_login_failed": "Kon niet inloggen (error: __error___)",
+    "error_logout_failed": "Kon niet uitloggen (error: __error___)",
+    "error_get_authenticated_state": "Kon login status niet ophalen (error: __error___)"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -2,6 +2,9 @@
   "reconnecting": "Bezig met verbinden...",
   "connecting": "Bezig met verbinden...",
   "offline": "Toon is onbereikbaar",
+  "re-authorize": "Log opnieuw in via de Toon App Instellingen.",
+  "device_absent_in_account": "Apparaat niet gevonden, probeer opnieuw in te loggen met het juiste Toon account.",
+  "oauth2_client_reset_failed": "Er is iets fout gegaan bij het opnieuw inloggen.",
   "initialization_error": "Er ging iets fout, error: __error__",
   "unauthenticated": "Toon is de verbinding kwijt, voeg het apparaat opnieuw toe",
   "repair_migration_v3": "Vanwege de incompatibiliteit tussen Toon API versies moet dit apparaat opnieuw worden toegevoegd.",
@@ -17,5 +20,13 @@
     "retry": "Probeer opnieuw",
     "installed_toon": "Deze Toon® is al geïnstalleerd!",
     "installed_toon_explained": "Het lijkt er op dat de Toon® die verbonden is met dit account reeds geïnstalleerd is op deze Homey, wil je nog een Toon apparaat toevoegen, probeer dan een ander account."
+  },
+  "settings": {
+    "title": "Toon Account",
+    "login_intro": "Klik hier om in te loggen met je Toon account.",
+    "login_button": "Login",
+    "logged_in": "Je bent momenteel ingelogd.",
+    "logout_intro": "Klik hier om uit te loggen.",
+    "logout_button": "Log uit"
   }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+  <script type="text/javascript" src="/homey.js" data-origin="settings"></script>
+</head>
+<body>
+<h1 data-i18n="settings.title"></h1>
+<div id="content">
+  <div id="login" style="display:none;">
+    <p data-i18n="settings.login_intro"></p>
+    <button id="login_btn" data-i18n="settings.login_button" onclick="login()"></button>
+  </div>
+  <div id="logout" style="display:none;">
+    <p data-i18n="settings.logged_in"></p>
+    <p data-i18n="settings.logout_intro"></p>
+    <button id="logout_btn" data-i18n="settings.logout_button" onclick="logout()"></button>
+  </div>
+</div>
+</body>
+</html>
+<script type="text/javascript">
+  function showLogin() {
+    document.getElementById('logout').style.display = 'none';
+    document.getElementById('login').style.display = 'block';
+  }
+
+  function showLogout() {
+    document.getElementById('login').style.display = 'none';
+    document.getElementById('logout').style.display = 'block';
+  }
+
+  function login() {
+    Homey.api('POST', '/login/', { state: true }, function (err, success) {
+      if (!err && success) showLogout()
+    });
+  }
+
+  function logout() {
+    Homey.api('POST', '/login/', { state: false }, function (err, success) {
+      if (!err && success) showLogin();
+    });
+  }
+
+  function onHomeyReady(Homey) {
+    Homey.on('url', url => Homey.openURL(url));
+    Homey.on('authorized', () => showLogout());
+    Homey.api('GET', '/login/', {}, function (err, loggedIn) {
+      if (loggedIn) {
+        showLogout()
+      } else {
+        showLogin()
+      }
+    });
+    Homey.ready();
+  }
+</script>

--- a/settings/index.html
+++ b/settings/index.html
@@ -44,6 +44,9 @@
   function onHomeyReady(Homey) {
     Homey.on('url', url => Homey.openURL(url));
     Homey.on('authorized', () => showLogout());
+    Homey.on('error', err => {
+      if (err) return Homey.alert(err.message || err);
+    });
     Homey.api('GET', '/login/', {}, function (err, loggedIn) {
       if (loggedIn) {
         showLogout()


### PR DESCRIPTION
This allows users to logout/login via the settings page, this might be useful when a device failed to refresh access tokens and is therefore unable to retrieve new access tokens. This method saves the user from re-pairing the device.

Also:
- Improved error messages
- Improved temperature state capability update
- Fixed an issue where capability sets would not resolve in time