### PR TITLE
Add option to override the default eneco tenant id from env.json

### DIFF
--- a/lib/ToonOAuth2Client.js
+++ b/lib/ToonOAuth2Client.js
@@ -34,9 +34,10 @@ class ToonOAuth2Client extends OAuth2Client {
    * @returns {string}
    */
 	onHandleAuthorizationURL({ scopes, state } = {}) {
+		const tenant = Homey.env.hasOwnProperty('TOON_TENANT_ID') ? Homey.env.TOON_TENANT_ID : 'eneco';
 		const query = {
 			state,
-			tenant_id: 'eneco', // add tenant id
+			tenant_id: tenant, // add tenant id
 			client_id: this._clientId,
 			response_type: 'code',
 			scope: this.onHandleAuthorizationURLScopes({ scopes }),


### PR DESCRIPTION
This will allow devs on eneco-acc or other tenant environments to
use this app.
A future improvement would be to let the end user select the value